### PR TITLE
1.21.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.2.9
+# 2.2.10
+
+* Update to support 1.21.8
+
+* # 2.2.9
 
 * Update to support 1.21.6
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
     id 'maven-publish'
     id "com.modrinth.minotaur" version "2.+"
 }
@@ -10,6 +10,7 @@ group = project.maven_group
 
 repositories {
     mavenLocal()
+    maven { url "https://maven.fabricmc.net" }
     maven { url "https://maven.nucleoid.xyz" }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url "https://maven.codedsakura.dev/releases" }
@@ -19,6 +20,9 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.minecraft_version}+${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    // Fabric API is required for attachments and blockview APIs in MC 1.21.8
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}+${project.minecraft_version}"
 
     modImplementation "dev.codedsakura.blossom:blossom-lib:${project.blossomlib_version}+${mc_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.2.9
+mod_version=2.2.10
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomHomes
 archives_base_name=blossom-homes
-supported_versions=1.21.5;1.21.6
+supported_versions=1.21.5;1.21.6;1.21.7;1.21.8
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.5
+minecraft_version=1.21.8
 yarn_mappings=build.1
-loader_version=0.16.10
+loader_version=0.16.14
 
 # Fabric API
-fabric_version=0.119.6
-blossomlib_version=2.5.12
+fabric_version=0.130.0
+blossomlib_version=2.5.15

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,8 @@
     "minecraft": [
       "${supported_versions}"
     ],
-    "blossom-lib": "^${blossomlib_version}"
+    "blossom-lib": "^${blossomlib_version}",
+    "fabric-api": "*"
   },
   "suggests": {
     "fabric-permissions-api-v0": "*"


### PR DESCRIPTION
I bumped BlossomLib/BlossomHomes to 1.21.8, here's the PR hoping it can save you some time.
The change required upgrading the gradle wrapper version.
Also I had to add a dependency to to fabric-api.

Requires https://github.com/BlossomMods/BlossomLib/pull/26 to run.


### Tests

Minecraft 1.21.5
 - fabric 0.16.14 and fabric 0.17.2
 - fabric-api mod 0.128.2+1.21.5


Minecraft 1.21.8
 - fabric 0.17.2
 - fabric-api mod 0.133.0+1.21.8
 - (I also had a bunch of other mods running as this is my usual instance)
 
 **I didn't test Minecraft versions 1.21.6 or 1.21.7.**